### PR TITLE
Add path or device id to MQTT topic

### DIFF
--- a/src/main/java/org/edgexfoundry/serviceactivator/MQTTOutboundServiceActivator.java
+++ b/src/main/java/org/edgexfoundry/serviceactivator/MQTTOutboundServiceActivator.java
@@ -74,7 +74,7 @@ public class MQTTOutboundServiceActivator {
 		// if path contains "\[any_string]" pre- or append dynamically device id to topic
 		// TODO - read "\[key]" from addressable and pre- or append its value to topic
 		String path = addressable.getPath();
-		if (path != null && !path.equals("")) {
+		if (path != null && path.length() > 1) {
 			String topic = addressable.getTopic();
 			if (path.charAt(0) == '/') {
 				addressable.setTopic(topic + path);


### PR DESCRIPTION
Paho MQTT client does not allow a path in a broker URL. Use addressable path
to append or prepend path or device id to topic and thus enable
an arbitrary MQTT broker URL path or MQTT broker URL path with
device id. 