### PR TITLE
Fixes MQTT URL construction to use Protocol

### DIFF
--- a/src/main/java/org/edgexfoundry/messaging/MQTTSender.java
+++ b/src/main/java/org/edgexfoundry/messaging/MQTTSender.java
@@ -64,8 +64,12 @@ public class MQTTSender implements MqttCallback {
 	}
 
 	public MQTTSender(Addressable addressable) {
-		this(addressable.getAddress(), addressable.getPort(), addressable.getPublisher(), addressable.getUser(),
+		this(buildBrokerUrl(addressable), addressable.getPort(), addressable.getPublisher(), addressable.getUser(),
 				addressable.getPassword(), addressable.getTopic(), 0, 3600);
+	}
+
+	private static String buildBrokerUrl(Addressable addressable) {
+		return addressable.getProtocol().toString().toLowerCase() + "://" + addressable.getAddress();
 	}
 
 	public boolean sendMessage(byte[] messagePayload) {

--- a/src/test/java/org/edgexfoundry/messaging/MQTTSenderTest.java
+++ b/src/test/java/org/edgexfoundry/messaging/MQTTSenderTest.java
@@ -22,6 +22,7 @@ package org.edgexfoundry.messaging;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_ADDRESS;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_PASSWORD;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_PORT;
+import static org.edgexfoundry.test.data.RegistrationData.TEST_PROTOCOL;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_PUBLISHER;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_TOPIC;
 import static org.edgexfoundry.test.data.RegistrationData.TEST_USER;
@@ -43,7 +44,7 @@ public class MQTTSenderTest {
 
 	@Before
 	public void setup() {
-		sender = new MQTTSender(TEST_ADDRESS, TEST_PORT, TEST_PUBLISHER, TEST_USER, TEST_PASSWORD, TEST_TOPIC, 0, 3600);
+		sender = new MQTTSender(TEST_PROTOCOL.toString().toLowerCase() + "://" + TEST_ADDRESS, TEST_PORT, TEST_PUBLISHER, TEST_USER, TEST_PASSWORD, TEST_TOPIC, 0, 3600);
 	}
 
 	@After
@@ -66,7 +67,7 @@ public class MQTTSenderTest {
 //	@Test
 //	public void testConnectFail() throws MqttException {
 //		// create a client already using the persistence path
-//		MqttClient client = new MqttClient(TEST_ADDRESS + ":" + TEST_PORT, TEST_PUBLISHER);
+//		MqttClient client = new MqttClient(TEST_PROTOCOL.toString().toLowerCase() + "://" + TEST_ADDRESS + ":" + TEST_PORT, TEST_PUBLISHER);
 //		MqttConnectOptions connOpts = new MqttConnectOptions();
 //		connOpts.setUserName(TEST_USER);
 //		connOpts.setPassword(TEST_PASSWORD.toCharArray());


### PR DESCRIPTION
Adds support for SSL encryption as a protocol, required by #18.
Fixes MQTT Test Sender initialization to use Protocol.

Requires https://github.com/edgexfoundry/export-test/pull/8.

Closes #22.

Signed-off-by: Tyler_Cox <tyler_cox@dell.com>